### PR TITLE
Fix environment variable SUBNET bug

### DIFF
--- a/setup/fleetLauncherApp/fleetLauncherLambda/app.py
+++ b/setup/fleetLauncherApp/fleetLauncherLambda/app.py
@@ -29,7 +29,7 @@ sim_job_params = {
       "simulationApplications": [],
       "vpcConfig": {
         "securityGroups": [ os.getenv('SECURITY_GROUP') ] if "SECURITY_GROUP" in os.environ else [],
-        "subnets": [ os.getenv('SUBNET_1'), os.getenv('SUBNET_1') ] if ("SUBNET_1" in os.environ and "SUBNET_2" in os.environ) else []
+        "subnets": [ os.getenv('SUBNET_1'), os.getenv('SUBNET_2') ] if ("SUBNET_1" in os.environ and "SUBNET_2" in os.environ) else []
       },
       "outputLocation": {
         "s3Bucket": os.getenv("S3_BUCKET"),


### PR DESCRIPTION
This will ensure two different subnets are used when launched with environment variables locally or through Lambda.

*Issue #, if available:*

*Description of changes:*
Modified SUBNET_1 to SUBNET_2 in line 32 of app.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
