### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/simulation_ws/src/robot_fleet/CMakeLists.txt
+++ b/simulation_ws/src/robot_fleet/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_fleet)
 
+cmake_policy(SET CMP0054 NEW)
+
 # c++11 if using kinetic
 add_definitions(-std=c++11)
 


### PR DESCRIPTION
This PR resolves the following error that appears during ```colcon build```:

> --- stderr: robot_fleet                                            
> CMake Warning (dev) at /usr/share/cmake-3.10/Modules/FindBoost.cmake:911 (if):
>   Policy CMP0054 is not set: Only interpret if() arguments as variables or
>   keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
>   details.  Use the cmake_policy command to set the policy and suppress this
>   warning.
> 
>   Quoted variables like "chrono" will no longer be dereferenced when the
>   policy is set to NEW.  Since the policy is not set the OLD behavior will be
>   used.
> Call Stack (most recent call first):
>   /usr/share/cmake-3.10/Modules/FindBoost.cmake:1558 (_Boost_MISSING_DEPENDENCIES)
>   /usr/share/OGRE/cmake/modules/FindOGRE.cmake:318 (find_package)
>   /usr/lib/x86_64-linux-gnu/cmake/gazebo/gazebo-config.cmake:175 (find_package)
>   CMakeLists.txt:15 (find_package)
> This warning is for project developers.  Use -Wno-dev to suppress it.

*Issue #, if available:* N/A

*Description of changes:*

Added the following line to CMakeLists.txt
```
cmake_policy(SET CMP0054 NEW)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
